### PR TITLE
Add metadata for privacy, sign-in, and terms pages

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import parse from "html-react-parser";
 import { marked } from "marked";
+import type { Metadata } from "next";
 import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "プライバシーポリシー",
+  description: "Magnezooのプライバシーポリシーページです。",
+};
 
 export default async function PrivacyPage() {
   const filePath = path.join(process.cwd(), "public", "privacy.md");

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,7 +1,13 @@
+import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
 import SignInPageClient from "./Client";
+
+export const metadata: Metadata = {
+  title: "サインイン",
+  description: "Magnezooのサインインページです。",
+};
 
 export default async function SignInPage({
   searchParams,

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import parse from "html-react-parser";
 import { marked } from "marked";
+import type { Metadata } from "next";
 import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "利用規約",
+  description: "Magnezooの利用規約ページです。",
+};
 
 export default async function PrivacyPage() {
   const filePath = path.join(process.cwd(), "public", "terms.md");


### PR DESCRIPTION
Enhance the privacy, sign-in, and terms pages by adding relevant metadata for improved SEO and user experience.