### PR TITLE
postしたあと、投稿しました(Successスナックバー)が表示された後も投稿したとき状態が残っている

### DIFF
--- a/src/components/Forms/Post/Client.tsx
+++ b/src/components/Forms/Post/Client.tsx
@@ -265,9 +265,8 @@ export default function PostFormClient({
 
       if (success) {
         enqueueSnackbar("投稿が保存されました！", { variant: "success" });
-        // リセットしてからモーダルを閉じる
-        resetForm();
-        onClose();
+        // クローズ処理は一箇所に集約
+        handleCloseLocal();
       } else {
         enqueueSnackbar("投稿の保存に失敗しました。", { variant: "error" });
       }


### PR DESCRIPTION
Fixes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * フォーム送信・モーダル閉鎖時にタイトル・説明・画像・タグなどの入力が確実にクリアされるように改善しました。
  * 画像プレビューが破棄され、ファイル入力の値もリセットされます。
  * マルチステップが最初の「タイトルと説明」に戻り、販売同意・利用規約のチェック状態も期待どおりに初期化されます。
  * 閉じる操作（背景クリック・閉じるボタン・送信成功時）で一貫してこれらが適用されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->