### PR TITLE
設定ページのSlack設定部分に「氏名」か「表示名」かの選択プルダウンを追加

### DIFF
--- a/src/app/(user)/settings/layout.tsx
+++ b/src/app/(user)/settings/layout.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { CssBaseline, createTheme, ThemeProvider } from "@mui/material";
+import { SnackbarProvider } from "notistack";
 import Header from "@/components/Header";
 
 const theme = createTheme({
@@ -19,7 +20,7 @@ export default function SettingsLayout({
       <div>
         <Header />
         <main className="max-w-5xl px-6 mx-auto mt-12 grid place-content-center">
-          {children}
+          <SnackbarProvider maxSnack={3}>{children}</SnackbarProvider>
         </main>
       </div>
     </ThemeProvider>

--- a/src/components/Forms/Settings/index.tsx
+++ b/src/components/Forms/Settings/index.tsx
@@ -7,12 +7,12 @@ import CircularProgress from "@mui/material/CircularProgress";
 import Divider from "@mui/material/Divider";
 import MenuItem from "@mui/material/MenuItem";
 import Select from "@mui/material/Select";
-import Snackbar from "@mui/material/Snackbar";
 import Stack from "@mui/material/Stack";
 import TextField from "@mui/material/TextField";
 import Typography from "@mui/material/Typography";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { useSnackbar } from "notistack";
 import { useEffect, useRef, useState } from "react";
 import DeleteAccountButton from "@/components/Buttons/Settings";
 import DeleteAccountDialog from "@/components/Dialogs/Settings";
@@ -60,7 +60,8 @@ const SettingsForm = ({
   const [isDisplayName, setIsDisplayName] = useState(
     initialSlackDisplayName ? "1" : "0",
   );
-  const [message, setMessage] = useState<string | null>(null);
+
+  const { enqueueSnackbar } = useSnackbar();
 
   const [previewUrl, setPreviewUrl] = useState(initialImage || "");
 
@@ -79,8 +80,9 @@ const SettingsForm = ({
   const handleFileSelect = (file: File) => {
     if (!ALLOWED_MIME_TYPES.has(file.type)) {
       setSelectedFile(null);
-      setMessage(
+      enqueueSnackbar(
         "対応していない画像形式です。JPEG/PNG/WebP/GIFを選択してください。",
+        { variant: "error" },
       );
       return;
     }
@@ -100,7 +102,10 @@ const SettingsForm = ({
       if (selectedFile) {
         const uploaded = await uploadProfileImage(selectedFile);
         if (uploaded.error || !uploaded.imageUrl) {
-          setMessage(uploaded.error || "画像アップロードに失敗しました。");
+          enqueueSnackbar(
+            uploaded.error || "画像アップロードに失敗しました。",
+            { variant: "error" },
+          );
           return;
         }
         imageUrl = uploaded.imageUrl;
@@ -113,7 +118,10 @@ const SettingsForm = ({
         });
 
         if (result.error) {
-          setMessage("保存に失敗しました。時間をおいて再度お試しください。");
+          enqueueSnackbar(
+            "保存に失敗しました。時間をおいて再度お試しください。",
+            { variant: "error" },
+          );
           return;
         }
       }
@@ -122,7 +130,12 @@ const SettingsForm = ({
       const trimmedNickName = nickName.trim();
       const nickNameResult = await updateNickName(trimmedNickName);
       if (!nickNameResult.success) {
-        setMessage(nickNameResult.error || "表示名の保存に失敗しました。");
+        enqueueSnackbar(
+          nickNameResult.error || "表示名の保存に失敗しました。",
+          {
+            variant: "error",
+          },
+        );
         return;
       }
 
@@ -135,19 +148,24 @@ const SettingsForm = ({
         );
 
         if (!slackResult.success) {
-          setMessage(slackResult.error || "Slack設定の保存に失敗しました。");
+          enqueueSnackbar(
+            slackResult.error || "Slack設定の保存に失敗しました。",
+            {
+              variant: "error",
+            },
+          );
           return;
         }
       }
 
       // 全て成功したら、保存済みの表示名を更新する（入力中だけでは反映しない）
       setSavedNickName(trimmedNickName);
-      setMessage("保存しました。");
+      enqueueSnackbar("保存しました。", { variant: "success" });
       setSelectedFile(null);
       router.refresh();
     } catch (error) {
       console.error(error);
-      setMessage("保存中にエラーが発生しました。");
+      enqueueSnackbar("保存中にエラーが発生しました。", { variant: "error" });
     } finally {
       saveLockRef.current = false;
       setSaving(false);
@@ -164,7 +182,9 @@ const SettingsForm = ({
     try {
       const result = await banSelfAccount();
       if (!result.success) {
-        setMessage(result.error || "アカウント削除に失敗しました。");
+        enqueueSnackbar(result.error || "アカウント削除に失敗しました。", {
+          variant: "error",
+        });
         return;
       }
 
@@ -173,7 +193,9 @@ const SettingsForm = ({
       router.push("/");
     } catch (error) {
       console.error(error);
-      setMessage("アカウント削除中にエラーが発生しました。");
+      enqueueSnackbar("アカウント削除中にエラーが発生しました。", {
+        variant: "error",
+      });
     } finally {
       deleteLockRef.current = false;
       setDeleting(false);
@@ -308,13 +330,6 @@ const SettingsForm = ({
         loading={deleting}
         onClose={() => setDeleteDialogOpen(false)}
         onConfirm={handleDeleteAccount}
-      />
-
-      <Snackbar
-        open={Boolean(message)}
-        autoHideDuration={2500}
-        onClose={() => setMessage(null)}
-        message={message}
       />
     </Stack>
   );


### PR DESCRIPTION
設定ページのSlack設定部分に「氏名」か「表示名」かの選択プルダウンを追加

Close #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Slack設定画面に表示名選択を追加し、「表示名」「氏名」を切り替え可能に。
* **改善**
  * サイト表示名欄の下に区切り線を追加し、レイアウトを整理。
  * 通知表示を改善し、即時の成功/エラースナックバーが適切に表示されるように（同時表示上限あり）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->