### PR TITLE
fix: ログイン時とログアウトのヘッダー表示を改善

### DIFF
--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -28,7 +28,7 @@ export default async function RootLayout({
   const session = await auth.api.getSession({
     headers: await headers(),
   });
-  const isAuthenticated = Boolean(session?.session);
+  const isAuthenticated = Boolean(session);
 
   return (
     <MUIWrapper>

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -28,9 +28,11 @@ export default async function RootLayout({
   const session = await auth.api.getSession({
     headers: await headers(),
   });
+  const isAuthenticated = Boolean(session?.session);
+
   return (
     <MUIWrapper>
-      <Header session={session?.session} />
+      <Header isAuthenticated={isAuthenticated} />
       {children}
       {detail}
       <Stack

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -2,12 +2,12 @@ import type { Metadata } from "next";
 import "../globals.css";
 import "./user.css";
 import { Stack } from "@mui/material";
+import { headers } from "next/headers";
 import Link from "next/link";
 import NameSettingGuard from "@/components/Dialogs/NameSettingGuard";
 import Header from "@/components/Header";
 import MUIWrapper from "@/components/MUIWrapper";
 import { auth } from "@/lib/auth";
-import { headers } from "next/headers";
 
 export const metadata: Metadata = {
   title: {
@@ -26,8 +26,8 @@ export default async function RootLayout({
   detail: React.ReactNode;
 }>) {
   const session = await auth.api.getSession({
-        headers: await headers()
-    });
+    headers: await headers(),
+  });
   return (
     <MUIWrapper>
       <Header session={session?.session} />

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -6,6 +6,8 @@ import Link from "next/link";
 import NameSettingGuard from "@/components/Dialogs/NameSettingGuard";
 import Header from "@/components/Header";
 import MUIWrapper from "@/components/MUIWrapper";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
 
 export const metadata: Metadata = {
   title: {
@@ -16,16 +18,19 @@ export const metadata: Metadata = {
     "Magnezooは、みんなのウチの子（ペットやキャラクターなど）を投稿して競う楽しいコンテストサイトです。かわいい、面白い、個性的なウチの子たちが大集合！ユーザーはお気に入りのウチの子に投票したり、コメントを残したりできます。さあ、あなたのウチの子も参加してみませんか？",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
   detail,
 }: Readonly<{
   children: React.ReactNode;
   detail: React.ReactNode;
 }>) {
+  const session = await auth.api.getSession({
+        headers: await headers()
+    });
   return (
     <MUIWrapper>
-      <Header />
+      <Header session={session?.session} />
       {children}
       {detail}
       <Stack

--- a/src/app/(user)/layout.tsx
+++ b/src/app/(user)/layout.tsx
@@ -25,10 +25,16 @@ export default async function RootLayout({
   children: React.ReactNode;
   detail: React.ReactNode;
 }>) {
-  const session = await auth.api.getSession({
-    headers: await headers(),
-  });
-  const isAuthenticated = Boolean(session);
+  let isAuthenticated = false;
+  try {
+    const session = await auth.api.getSession({
+      headers: await headers(),
+    });
+    isAuthenticated = Boolean(session);
+  } catch (error) {
+    console.error("Failed to fetch session:", error);
+    isAuthenticated = false;
+  }
 
   return (
     <MUIWrapper>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -12,7 +12,6 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Toolbar from "@mui/material/Toolbar";
-import type { Session } from "better-auth";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -20,9 +19,9 @@ import { useState } from "react";
 import { authClient } from "@/lib/auth-client";
 
 export default function ButtonAppBar({
-  session,
+  isAuthenticated,
 }: {
-  session: Session | undefined;
+  isAuthenticated: boolean;
 }) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const menuOpen = Boolean(anchorEl);
@@ -37,9 +36,15 @@ export default function ButtonAppBar({
   };
 
   const handleLogout = async () => {
-    await authClient.signOut();
-    handleCloseMenu();
-    router.push("/signin");
+    try {
+      await authClient.signOut();
+      router.push("/signin");
+    } catch (error) {
+      console.error("Logout failed:", error);
+      alert("ログアウトに失敗しました。");
+    } finally {
+      handleCloseMenu();
+    }
   };
 
   const DrawerHeader = styled("div")(({ theme }) => ({
@@ -117,7 +122,7 @@ export default function ButtonAppBar({
                 </ListItemIcon>
                 個人設定
               </MenuItem>
-              {session ? (
+              {isAuthenticated ? (
                 <MenuItem onClick={handleLogout}>
                   <ListItemIcon>
                     <LogoutIcon fontSize="small" />

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -112,23 +112,25 @@ export default function ButtonAppBar({
               anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
               transformOrigin={{ vertical: "top", horizontal: "right" }}
             >
-              <MenuItem
-                component={Link}
-                href="/settings"
-                onClick={handleCloseMenu}
-              >
-                <ListItemIcon>
-                  <SettingsIcon fontSize="small" />
-                </ListItemIcon>
-                個人設定
-              </MenuItem>
               {isAuthenticated ? (
-                <MenuItem onClick={handleLogout}>
-                  <ListItemIcon>
-                    <LogoutIcon fontSize="small" />
-                  </ListItemIcon>
-                  ログアウト
-                </MenuItem>
+                <>
+                  <MenuItem
+                    component={Link}
+                    href="/settings"
+                    onClick={handleCloseMenu}
+                  >
+                    <ListItemIcon>
+                      <SettingsIcon fontSize="small" />
+                    </ListItemIcon>
+                    個人設定
+                  </MenuItem>
+                  <MenuItem onClick={handleLogout}>
+                    <ListItemIcon>
+                      <LogoutIcon fontSize="small" />
+                    </ListItemIcon>
+                    ログアウト
+                  </MenuItem>
+                </>
               ) : (
                 <MenuItem
                   component={Link}

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import LogoutIcon from "@mui/icons-material/Logout";
+import LoginIcon from "@mui/icons-material/Login";
 import MenuIcon from "@mui/icons-material/Menu";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { styled } from "@mui/material";
@@ -16,8 +17,13 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { authClient } from "@/lib/auth-client";
+import { type Session } from "better-auth";
 
-export default function ButtonAppBar() {
+export default function ButtonAppBar({
+  session,
+}: {
+  session: Session | undefined;
+}) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const menuOpen = Boolean(anchorEl);
   const router = useRouter();
@@ -111,12 +117,25 @@ export default function ButtonAppBar() {
                 </ListItemIcon>
                 個人設定
               </MenuItem>
-              <MenuItem onClick={handleLogout}>
-                <ListItemIcon>
-                  <LogoutIcon fontSize="small" />
-                </ListItemIcon>
-                ログアウト
-              </MenuItem>
+              {session ? (
+                <MenuItem onClick={handleLogout}>
+                  <ListItemIcon>
+                    <LogoutIcon fontSize="small" />
+                  </ListItemIcon>
+                  ログアウト
+                </MenuItem>
+              ) : (
+                <MenuItem
+                  component={Link}
+                  href="/signin"
+                  onClick={handleCloseMenu}
+                >
+                  <ListItemIcon>
+                    <LoginIcon fontSize="small" />
+                  </ListItemIcon>
+                  ログイン
+                </MenuItem>
+              )}
             </Menu>
           </Toolbar>
         </AppBar>

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import LogoutIcon from "@mui/icons-material/Logout";
 import LoginIcon from "@mui/icons-material/Login";
+import LogoutIcon from "@mui/icons-material/Logout";
 import MenuIcon from "@mui/icons-material/Menu";
 import SettingsIcon from "@mui/icons-material/Settings";
 import { styled } from "@mui/material";
@@ -12,12 +12,12 @@ import ListItemIcon from "@mui/material/ListItemIcon";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import Toolbar from "@mui/material/Toolbar";
+import type { Session } from "better-auth";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { authClient } from "@/lib/auth-client";
-import { type Session } from "better-auth";
 
 export default function ButtonAppBar({
   session,


### PR DESCRIPTION

ログインしていない状態

<img width="191" height="222" alt="image" src="https://github.com/user-attachments/assets/d8367778-8a5e-4118-9163-e13a4b8ca238" />

ログインしている状態

<img width="199" height="196" alt="image" src="https://github.com/user-attachments/assets/c7e9d349-a7a6-4ebd-a6df-01f64785b94f" />

fix #116 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * レイアウトで取得したサーバー側認証状態をヘッダーメニューに渡し、認証状態に応じて表示を動的に切替します（認証時は個人設定・ログアウト、未認証時はログイン）。
* **バグ修正**
  * ログアウト処理の安定性を強化。エラー時のログ出力と通知を追加し、処理後にメニューが確実に閉じるようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->