### PR TITLE
OGPを動的生成して投稿ページに対してもOGPを表示する

### DIFF
--- a/src/app/(user)/(posts)/posts/[id]/page.tsx
+++ b/src/app/(user)/(posts)/posts/[id]/page.tsx
@@ -1,6 +1,5 @@
 import { Stack, Typography } from "@mui/material";
 import type { Metadata } from "next";
-import { headers } from "next/headers";
 import { Suspense } from "react";
 import PostDetailDialog from "@/components/Dialogs/PostDetail";
 import prisma from "@/lib/prisma";
@@ -36,12 +35,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return {
       title: "投稿が見つかりませんでした",
       description: `投稿ID: ${id}の詳細ページは存在しません。`,
+      robots: "noindex, nofollow",
     };
   }
-  const header = await headers();
-  const protocol = header.get("x-forwarded-proto") || "http";
-  const host =
-    header.get("host") || header.get("x-forwarded-host") || "localhost:3000";
   const tags = post.tags.map((t) => t.tag.name);
   const authorName =
     post.author.nickName ||
@@ -50,11 +46,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     "匿名ユーザー";
   return {
     title: `${post.title}`,
-    description: `${post.description.slice(0, 100)}...`,
+    description: `${post.description.slice(0, 100)}${post.description.length > 100 ? "..." : ""}`,
     openGraph: {
       title: `${post.title}`,
-      description: `${post.description.slice(0, 100)}...`,
-      images: `${protocol}://${host}${post.imageUrl}`,
+      description: `${post.description.slice(0, 100)}${post.description.length > 100 ? "..." : ""}`,
+      images: `${process.env.BETTER_AUTH_URL}${post.imageUrl}`,
       type: "article",
       tags,
       authors: [authorName],
@@ -63,8 +59,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     twitter: {
       card: "summary_large_image",
       title: `${post.title}`,
-      description: `${post.description.slice(0, 100)}...`,
-      images: `${protocol}://${host}${post.imageUrl}`,
+      description: `${post.description.slice(0, 100)}${post.description.length > 100 ? "..." : ""}`,
+      images: `${process.env.BETTER_AUTH_URL}${post.imageUrl}`,
     },
   };
 }

--- a/src/app/(user)/(posts)/posts/[id]/page.tsx
+++ b/src/app/(user)/(posts)/posts/[id]/page.tsx
@@ -1,7 +1,73 @@
 import { Stack, Typography } from "@mui/material";
+import type { Metadata } from "next";
+import { headers } from "next/headers";
 import { Suspense } from "react";
 import PostDetailDialog from "@/components/Dialogs/PostDetail";
+import prisma from "@/lib/prisma";
 import ResolvedPostsPage from "../using";
+
+type Props = {
+  params: Promise<{ id: string }>;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { id } = await params;
+  const post = await prisma.post.findUnique({
+    where: { id },
+    select: {
+      title: true,
+      description: true,
+      imageUrl: true,
+      tags: {
+        select: { tag: { select: { name: true } } },
+      },
+      author: {
+        select: {
+          slacks: {
+            select: { name: true, isDisplayname: true },
+          },
+          nickName: true,
+        },
+      },
+      createdAt: true,
+    },
+  });
+  if (!post) {
+    return {
+      title: "投稿が見つかりませんでした",
+      description: `投稿ID: ${id}の詳細ページは存在しません。`,
+    };
+  }
+  const header = await headers();
+  const protocol = header.get("x-forwarded-proto") || "http";
+  const host =
+    header.get("host") || header.get("x-forwarded-host") || "localhost:3000";
+  const tags = post.tags.map((t) => t.tag.name);
+  const authorName =
+    post.author.nickName ||
+    post.author.slacks.find((s) => s.isDisplayname)?.name ||
+    post.author.slacks[0]?.name ||
+    "匿名ユーザー";
+  return {
+    title: `${post.title}`,
+    description: `${post.description.slice(0, 100)}...`,
+    openGraph: {
+      title: `${post.title}`,
+      description: `${post.description.slice(0, 100)}...`,
+      images: `${protocol}://${host}${post.imageUrl}`,
+      type: "article",
+      tags,
+      authors: [authorName],
+      publishedTime: post.createdAt.toISOString(),
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${post.title}`,
+      description: `${post.description.slice(0, 100)}...`,
+      images: `${protocol}://${host}${post.imageUrl}`,
+    },
+  };
+}
 
 export default async function PostDetailPage({
   params,


### PR DESCRIPTION
Resolve #119

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 投稿ページのメタデータが自動生成されるようになりました（タイトル、100文字を超える説明は省略して末尾に省略記号を追加、タグ、著者、公開日時、画像など）。
  * Open Graph と Twitter カード向けメタ情報を自動設定するようになりました（カード画像対応含む）。
  * 投稿が存在しない場合は日本語のフォールバック表示と robots: noindex,nofollow 指定で検索インデックスを防止します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->