### PR TITLE
一般ユーザー権限での編集画面で、間違ったリダイレクト先を適切なパスに変更

### DIFF
--- a/src/app/(user)/(posts)/posts/[id]/edit/PostEditForm.tsx
+++ b/src/app/(user)/(posts)/posts/[id]/edit/PostEditForm.tsx
@@ -93,7 +93,7 @@ function PostEditFormContent({ post }: { post: PostWithTags }) {
       });
 
       if (ok) {
-        router.push(`/admin/posts/${post.id}`);
+        router.push(`/posts/${post.id}`);
       } else {
         enqueueSnackbar("更新に失敗しました", { variant: "error" });
       }


### PR DESCRIPTION
## 概要
`admin/**` となっていたのを一般ユーザーでもみれる`posts/(ポストのID)`に変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 投稿編集完了後のリダイレクト先を修正し、ユーザーをより適切なページに遷移させるようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->