### PR TITLE
画像の表示部分をスライダーで設定できるようにする(上下のみ)

### DIFF
--- a/prisma/migrations/20260419234551_add_post_pos_y/migration.sql
+++ b/prisma/migrations/20260419234551_add_post_pos_y/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "post" ADD COLUMN     "imagePositionY" INTEGER NOT NULL DEFAULT 50;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -107,6 +107,7 @@ model Post {
   description        String      @db.Text
   imageUrl           String
   authorId           String
+  imagePositionY     Int         @default(50)
   isSalesApplication Boolean     @default(false)
   isStudio           Boolean     @default(false)
   studioMgmtNo       Int?

--- a/src/app/(user)/(posts)/posts/[id]/edit/PostEditForm.tsx
+++ b/src/app/(user)/(posts)/posts/[id]/edit/PostEditForm.tsx
@@ -38,6 +38,7 @@ type PostWithTags = {
   title: string;
   description: string;
   imageUrl: string;
+  imagePositionY: number;
   isSalesApplication: boolean;
   tags: { tag: Tag }[];
 };
@@ -53,6 +54,7 @@ function PostEditFormContent({ post }: { post: PostWithTags }) {
   const [title, setTitle] = useState(post.title);
   const [description, setDescription] = useState(post.description);
   const [image, setImage] = useState<File | null>(null);
+  const [imagePosition, setImagePosition] = useState(post.imagePositionY ?? 50);
   const [selectedTags, setSelectedTags] = useState<(Tag | string)[]>(
     post.tags.map((t) => t.tag),
   );
@@ -87,6 +89,7 @@ function PostEditFormContent({ post }: { post: PostWithTags }) {
         title,
         content: description,
         image,
+        imagePositionY: imagePosition,
         isSalesApplication: salesAgreementChecked,
         tagNames,
         userId: session.user.id,
@@ -178,6 +181,8 @@ function PostEditFormContent({ post }: { post: PostWithTags }) {
             setImage={setImage}
             existingImageUrl={post.imageUrl}
             disabled={submitting}
+            imagePosition={imagePosition}
+            setImagePosition={setImagePosition}
           />
 
           <PostTagField

--- a/src/app/(user)/(posts)/posts/[id]/edit/PostEditForm.tsx
+++ b/src/app/(user)/(posts)/posts/[id]/edit/PostEditForm.tsx
@@ -54,7 +54,7 @@ function PostEditFormContent({ post }: { post: PostWithTags }) {
   const [title, setTitle] = useState(post.title);
   const [description, setDescription] = useState(post.description);
   const [image, setImage] = useState<File | null>(null);
-  const [imagePosition, setImagePosition] = useState(post.imagePositionY ?? 50);
+  const [imagePosition, setImagePosition] = useState(post.imagePositionY);
   const [selectedTags, setSelectedTags] = useState<(Tag | string)[]>(
     post.tags.map((t) => t.tag),
   );

--- a/src/app/admin/posts/[id]/edit/PostEditForm.tsx
+++ b/src/app/admin/posts/[id]/edit/PostEditForm.tsx
@@ -37,6 +37,7 @@ type PostWithTags = {
   title: string;
   description: string;
   imageUrl: string;
+  imagePositionY?: number;
   isSalesApplication: boolean;
   isStudio: boolean;
   studioMgmtNo: number | null;
@@ -49,6 +50,7 @@ const DEFAULT_NEW_POST: PostWithTags = {
   title: "",
   description: "",
   imageUrl: "",
+  imagePositionY: 50,
   isSalesApplication: false,
   isStudio: false,
   studioMgmtNo: null,
@@ -78,6 +80,9 @@ function PostEditFormContent({
   const [title, setTitle] = useState(currentPost.title);
   const [description, setDescription] = useState(currentPost.description);
   const [image, setImage] = useState<File | null>(null);
+  const [imagePosition, setImagePosition] = useState(
+    currentPost.imagePositionY ?? 50,
+  );
   const [selectedTags, setSelectedTags] = useState<(Tag | string)[]>(
     currentPost.tags.map((t) => t.tag),
   );
@@ -134,6 +139,7 @@ function PostEditFormContent({
             title,
             content: description,
             image: compressedImage as File,
+            imagePositionY: imagePosition,
             userId: session.user.id,
             authorId: selectedAuthorId,
             isSalesApplication: salesAgreementChecked,
@@ -146,6 +152,7 @@ function PostEditFormContent({
             title,
             content: description,
             image: compressedImage,
+            imagePositionY: imagePosition,
             isSalesApplication: salesAgreementChecked,
             isStudio: isStudioChecked,
             studioMgmtNo: parsedStudioMgmtNo,
@@ -267,6 +274,8 @@ function PostEditFormContent({
             setImage={setImage}
             existingImageUrl={currentPost.imageUrl || undefined}
             disabled={submitting}
+            imagePosition={imagePosition}
+            setImagePosition={setImagePosition}
           />
 
           <PostTagField

--- a/src/components/Cards/PostCard.tsx
+++ b/src/components/Cards/PostCard.tsx
@@ -15,20 +15,22 @@ import {
 } from "@mui/material";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import {
-  type Post,
-  SalesType,
-  type Slacks,
-  type User,
-} from "@/generated/prisma/browser";
+import type { Post, Slacks, User } from "@/generated/prisma/browser";
 import VoteButton from "../Buttons/Vote";
 import AuthorCard from "./AuthorCard";
 
+enum SalesType {
+  NONE = "NONE",
+  ACRYLIC_KEYCHAIN = "ACRYLIC_KEYCHAIN",
+  BADGE = "BADGE",
+  STICKER = "STICKER",
+}
 export interface UserWithSlacks extends User {
   slacks: Omit<Slacks, "userId" | "id" | "createdAt" | "updatedAt">[];
 }
 
 export interface PostWithAutherAndVotes extends Post {
+  imagePositionY: number;
   author: UserWithSlacks;
   votes: {
     userId: string;
@@ -104,6 +106,7 @@ export default function PostCard({
               borderTopLeftRadius: 4,
               borderTopRightRadius: 4,
               cursor: "pointer",
+              bgcolor: "grey.100",
             }}
           >
             <Image
@@ -112,6 +115,7 @@ export default function PostCard({
               fill
               style={{
                 objectFit: "cover",
+                objectPosition: `center ${post.imagePositionY ?? 50}%`,
               }}
               sizes="(max-width: 768px) 100vw, 450px"
               fetchPriority={index !== undefined && index < 5 ? "high" : "auto"}

--- a/src/components/Cards/PostCard.tsx
+++ b/src/components/Cards/PostCard.tsx
@@ -16,21 +16,15 @@ import {
 import Image from "next/image";
 import { useRouter } from "next/navigation";
 import type { Post, Slacks, User } from "@/generated/prisma/browser";
+import { SalesType } from "@/generated/prisma/browser";
 import VoteButton from "../Buttons/Vote";
 import AuthorCard from "./AuthorCard";
 
-enum SalesType {
-  NONE = "NONE",
-  ACRYLIC_KEYCHAIN = "ACRYLIC_KEYCHAIN",
-  BADGE = "BADGE",
-  STICKER = "STICKER",
-}
 export interface UserWithSlacks extends User {
   slacks: Omit<Slacks, "userId" | "id" | "createdAt" | "updatedAt">[];
 }
 
 export interface PostWithAutherAndVotes extends Post {
-  imagePositionY: number;
   author: UserWithSlacks;
   votes: {
     userId: string;

--- a/src/components/Forms/Post/Client.tsx
+++ b/src/components/Forms/Post/Client.tsx
@@ -612,6 +612,17 @@ export default function PostFormClient({
                                       valueLabelDisplay="auto"
                                     />
                                   </Stack>
+                                  <Button
+                                    variant="text"
+                                    onClick={() => setImagePosition(50)}
+                                    disabled={submitting}
+                                    sx={{
+                                      display: "flex",
+                                      justifyContent: "flex-end",
+                                    }}
+                                  >
+                                    表示位置をリセット
+                                  </Button>
                                   <Typography
                                     variant="caption"
                                     color="text.secondary"

--- a/src/components/Forms/Post/Client.tsx
+++ b/src/components/Forms/Post/Client.tsx
@@ -15,6 +15,7 @@ import {
   IconButton,
   MenuItem,
   MenuList,
+  Slider,
   Stack,
   TextField,
   Typography,
@@ -28,7 +29,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { createPost, getTags } from "./action";
+import { createPost, getTags } from "@/components/Forms/Post/action";
 
 type Tag = { id: string; name: string };
 
@@ -81,6 +82,7 @@ export default function PostFormClient({
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [image, setImage] = useState<File | null>(null);
+  const [imagePosition, setImagePosition] = useState(50); // 追加: 画像の表示位置 (0-100)
   const [availableTags, setAvailableTags] = useState<Tag[]>([]);
   const [selectedTags, setSelectedTags] = useState<(Tag | string)[]>([]);
   const [tagInputValue, setTagInputValue] = useState("");
@@ -128,6 +130,7 @@ export default function PostFormClient({
     setTitle("");
     setDescription("");
     setImage(null);
+    setImagePosition(50); // リセット時にも中央に戻す
     if (fileInputRef.current) {
       try {
         // clear file input value
@@ -159,6 +162,7 @@ export default function PostFormClient({
     setImage(
       e.target.files && e.target.files.length > 0 ? e.target.files[0] : null,
     );
+    setImagePosition(50); // 画像が変更されたら位置をリセット
   };
 
   useEffect(() => {
@@ -258,6 +262,7 @@ export default function PostFormClient({
         title: String(title),
         content: String(description),
         image: compressedImage,
+        imagePositionY: imagePosition, // 追加: Actionへ渡す
         userId,
         isSalesApplication: salesAgreementChecked,
         tagNames,
@@ -550,14 +555,10 @@ export default function PostFormClient({
                             <Box
                               sx={{
                                 display: "flex",
-                                gap: 4,
-                                mt: 4,
-                                flexWrap: "wrap",
+                                flexDirection: "column",
+                                gap: 2,
+                                mt: 2,
                                 width: "100%",
-                                justifyContent: {
-                                  xs: "center",
-                                  xl: "flex-start",
-                                },
                               }}
                             >
                               <Box
@@ -567,18 +568,59 @@ export default function PostFormClient({
                                   textAlign: "center",
                                 }}
                               >
+                                <Typography
+                                  variant="subtitle2"
+                                  gutterBottom
+                                  align="left"
+                                >
+                                  プレビュー (16:9 表示枠)
+                                </Typography>
                                 <Box
                                   component="img"
                                   src={preview.url}
                                   alt={preview.name}
                                   sx={{
                                     width: "100%",
-                                    height: { xs: 200, sm: 240 },
+                                    aspectRatio: "16/9", // 16:9 に固定
                                     objectFit: "cover",
+                                    objectPosition: `center ${imagePosition}%`, // スライダーの値を反映
                                     borderRadius: 2,
                                     border: "1px solid #e0e0e0",
+                                    bgcolor: "grey.100",
                                   }}
                                 />
+                                <Box sx={{ mt: 2, width: "100%" }}>
+                                  <Stack
+                                    direction="row"
+                                    spacing={2}
+                                    alignItems="center"
+                                  >
+                                    <Typography
+                                      variant="caption"
+                                      sx={{ minWidth: 80, fontWeight: "bold" }}
+                                    >
+                                      表示位置(上下)
+                                    </Typography>
+                                    <Slider
+                                      value={imagePosition}
+                                      min={0}
+                                      max={100}
+                                      onChange={(_, value) =>
+                                        setImagePosition(value as number)
+                                      }
+                                      disabled={submitting}
+                                      valueLabelDisplay="auto"
+                                    />
+                                  </Stack>
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    align="left"
+                                    display="block"
+                                  >
+                                    ※スライダーを動かして、枠内に表示したい部分を調整してください。
+                                  </Typography>
+                                </Box>
                                 <Typography
                                   sx={{ fontSize: { xs: 14, xl: 14 }, mt: 1 }}
                                   noWrap

--- a/src/components/Forms/Post/action.ts
+++ b/src/components/Forms/Post/action.ts
@@ -19,6 +19,7 @@ export const createPost = async ({
   title,
   content,
   image,
+  imagePositionY,
   userId,
   authorId,
   isSalesApplication,
@@ -29,6 +30,7 @@ export const createPost = async ({
   title: string;
   content: string;
   image: File;
+  imagePositionY?: number;
   userId: string;
   authorId?: string;
   isSalesApplication: boolean;
@@ -95,6 +97,7 @@ export const createPost = async ({
         title,
         description: content,
         imageUrl,
+        imagePositionY,
         isSalesApplication,
         isStudio: isStudioToSave,
         studioMgmtNo: studioMgmtNoToSave,
@@ -130,6 +133,7 @@ export const updatePost = async ({
   title,
   content,
   image,
+  imagePositionY,
   isSalesApplication,
   isStudio,
   studioMgmtNo,
@@ -140,6 +144,7 @@ export const updatePost = async ({
   title: string;
   content: string;
   image?: File | null;
+  imagePositionY?: number; // 追加
   isSalesApplication: boolean;
   isStudio?: boolean;
   studioMgmtNo?: number | null;
@@ -224,6 +229,7 @@ export const updatePost = async ({
       title: string;
       description: string;
       isSalesApplication: boolean;
+      imagePositionY?: number;
       imageUrl?: string;
       authorId?: string;
       isStudio?: boolean;
@@ -243,6 +249,7 @@ export const updatePost = async ({
       title,
       description: content,
       isSalesApplication,
+      imagePositionY,
       ...(imageUrl ? { imageUrl } : {}),
       tags: {
         deleteMany: {},

--- a/src/components/admin/PostEditor/PostImageField.tsx
+++ b/src/components/admin/PostEditor/PostImageField.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Button, Stack, Typography } from "@mui/material";
+import { Box, Button, Slider, Stack, Typography } from "@mui/material";
 import { useEffect, useMemo, useRef } from "react";
 
 export default function PostImageField({
@@ -8,11 +8,15 @@ export default function PostImageField({
   setImage,
   existingImageUrl,
   disabled,
+  imagePosition,
+  setImagePosition,
 }: {
   image: File | null;
   setImage: (f: File | null) => void;
   existingImageUrl?: string;
   disabled: boolean;
+  imagePosition: number;
+  setImagePosition: (val: number) => void;
 }) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -55,17 +59,49 @@ export default function PostImageField({
         onChange={(e) => setImage(e.target.files?.[0] || null)}
       />
       {previewUrl && (
-        <Box
-          component="img"
-          src={previewUrl}
-          sx={{
-            width: "100%",
-            maxHeight: 400,
-            objectFit: "contain",
-            borderRadius: 1,
-            border: "1px solid #ddd",
-          }}
-        />
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle2" gutterBottom>
+            プレビュー (16:9 表示枠)
+          </Typography>
+
+          <Box
+            component="img"
+            src={previewUrl}
+            sx={{
+              width: "100%",
+              aspectRatio: "16/9",
+              objectFit: "cover",
+              objectPosition: `center ${imagePosition}%`,
+              borderRadius: 1,
+              border: "1px solid #ddd",
+              bgcolor: "grey.100", // 画像読み込み前や透過画像の背景用
+            }}
+          />
+
+          <Box sx={{ mt: 2, px: 1 }}>
+            <Stack direction="row" spacing={2} alignItems="center">
+              <Typography
+                variant="caption"
+                sx={{ minWidth: 80, fontWeight: "bold" }}
+              >
+                表示位置(上下)
+              </Typography>
+              <Slider
+                value={imagePosition}
+                min={0}
+                max={100}
+                onChange={(_, value) => setImagePosition(value as number)}
+                disabled={disabled}
+                valueLabelDisplay="auto"
+              />
+            </Stack>
+            <Typography variant="caption" color="text.secondary">
+              {
+                "※スライダーを動かして、16:9の枠内に表示したい部分を調整してください。"
+              }
+            </Typography>
+          </Box>
+        </Box>
       )}
     </Box>
   );


### PR DESCRIPTION
無茶振りに対応しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 投稿の作成・編集で画像の垂直表示位置をスライダーで調整可能になりました（保存されます）。
  * 投稿一覧やカードの画像プレビューが設定した垂直位置を反映して表示されます。
* **変更**
  * 新規・既存投稿はデフォルトで垂直位置が50％に設定されます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->